### PR TITLE
Changes required to pass unit tests with REBOUND Version 4

### DIFF
--- a/celmech/miscellaneous.py
+++ b/celmech/miscellaneous.py
@@ -338,8 +338,8 @@ def AMD_stable_Q(sim):
     for i in range(len(ps)-1):
         pIn = ps[i]
         pOut = ps[i+1]
-        orbIn = pIn.calculate_orbit(pstar)
-        orbOut = pOut.calculate_orbit(pstar)
+        orbIn = pIn.orbit(pstar)
+        orbOut = pOut.orbit(pstar)
         alpha = orbIn.a / orbOut.a
         gamma = pIn.m / pOut.m
         LmbdaOut = pOut.m * np.sqrt(orbOut.a)
@@ -386,8 +386,8 @@ def AMD_stability_coefficients(sim,overlap=False):
     for i in range(len(ps)-1):
         pIn = ps[i]
         pOut = ps[i+1]
-        orbIn = pIn.calculate_orbit(pstar)
-        orbOut = pOut.calculate_orbit(pstar)
+        orbIn = pIn.orbit(pstar)
+        orbOut = pOut.orbit(pstar)
         alpha = orbIn.a / orbOut.a
         gamma = pIn.m / pOut.m
         LmbdaOut = pOut.m * np.sqrt(orbOut.a)

--- a/celmech/nbody_simulation_utilities.py
+++ b/celmech/nbody_simulation_utilities.py
@@ -61,11 +61,11 @@ def get_simarchive_integration_results(sa,coordinates='jacobi'):
 
 def _get_rebound_simarchive_integration_results(sa,coordinates):
     if coordinates == 'jacobi':
-        get_orbits = lambda sim: sim.calculate_orbits(jacobi_masses=True)
+        get_orbits = lambda sim: sim.orbits(jacobi_masses=True)
     elif coordinates == 'heliocentric':
         get_orbits = get_canonical_heliocentric_orbits
     elif coordinates == 'barycentric':
-        get_orbits = lambda sim: sim.calculate_orbits(sim.calculate_com())
+        get_orbits = lambda sim: sim.orbits(sim.calculate_com())
     else: 
         raise ValueError("'Coordinates must be one of 'jacobi','heliocentric', or 'barycentric'")
     N = len(sa)
@@ -101,11 +101,11 @@ def _get_rebound_simarchive_integration_results(sa,coordinates):
 
 def _get_reboundx_simarchive_integration_results(sa,coordinates):
     if coordinates == 'jacobi':
-        get_orbits = lambda sim: sim.calculate_orbits(jacobi_masses=True)
+        get_orbits = lambda sim: sim.orbits(jacobi_masses=True)
     elif coordinates == 'heliocentric':
         get_orbits = get_canonical_heliocentric_orbits
     elif coordinates == 'barycentric':
-        get_orbits = lambda sim: sim.calculate_orbits(sim.calculate_com())
+        get_orbits = lambda sim: sim.orbits(sim.calculate_com())
     else: 
        raise ValueError("'Coordinates must be one of 'jacobi','heliocentric', or 'barycentric'")
     N = len(sa)
@@ -226,7 +226,7 @@ def reb_calculate_orbits(sim, coordinates="canonical heliocentric"):
             vy = v_for_orbit[1],
             vz = v_for_orbit[2]
         )
-        orbit = fictitious_particle.calculate_orbit(primary=fictitious_star,G = sim.G)
+        orbit = fictitious_particle.orbit(primary=fictitious_star,G = sim.G)
         orbits.append(orbit)
     return orbits
 

--- a/celmech/planar_poincare.py
+++ b/celmech/planar_poincare.py
@@ -108,7 +108,7 @@ class PlanarPoincare(object):
         mjac, Mjac = masses_to_jacobi(masses)
         pvars = PlanarPoincare(sim.G)
         ps = sim.particles
-        o = sim.calculate_orbits(jacobi_masses=True)
+        o = sim.orbits(jacobi_masses=True)
         for i in range(1,sim.N-sim.N_var):
             M = Mjac[i]
             m = mjac[i]

--- a/celmech/test/test_poincare.py
+++ b/celmech/test/test_poincare.py
@@ -41,8 +41,8 @@ class TestPoincare(unittest.TestCase):
 
     def compare_simulations_orb(self, sim1, sim2, delta=1.e-15):
         self.assertAlmostEqual(sim1.particles[0].m, sim2.particles[0].m, delta=delta)
-        orbs1 = sim1.calculate_orbits()
-        orbs2 = sim2.calculate_orbits()
+        orbs1 = sim1.orbits()
+        orbs2 = sim2.orbits()
         for i in range(sim1.N-1):
             self.assertAlmostEqual(sim1.particles[i+1].m, sim2.particles[i+1].m, delta=delta, msg="mass")
             o1 = orbs1[i]
@@ -180,7 +180,7 @@ def averaging_error(Nseed):
     sim = packed_sim(Nseed)
     ps = sim.particles
 
-    o = sim.calculate_orbits(jacobi_masses=True)
+    o = sim.orbits(jacobi_masses=True)
     a10 = o[0].a
     a20 = o[1].a
     a30 = o[2].a
@@ -197,7 +197,7 @@ def averaging_error(Nseed):
 
     for i,t in enumerate(times):
         # Store N-body data
-        o = sim.calculate_orbits(jacobi_masses=True)
+        o = sim.orbits(jacobi_masses=True)
         Nsma[0,i]=o[0].a
         Nsma[1,i]=o[1].a
         Nsma[2,i]=o[2].a

--- a/jupyter_examples/CoordinatesConvertingToFromNbody.ipynb
+++ b/jupyter_examples/CoordinatesConvertingToFromNbody.ipynb
@@ -77,7 +77,7 @@
     }
    ],
    "source": [
-    "for o in sim.calculate_orbits():\n",
+    "for o in sim.orbits():\n",
     "    print(o)"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ libcelmechmodule = Extension('libcelmech',
                     )
 
 if not os.getenv('READTHEDOCS'):
-    packages = ['theano', 'sympy>=1.1.1', 'numpy', 'scipy>=1.2.0', 'reboundx>=3.1.0', 'rebound>=3.5.11', 'mpmath>=1.0.0']
+    packages = ['theano', 'sympy>=1.1.1', 'numpy', 'scipy>=1.2.0', 'reboundx>=3.1.0', 'rebound>=4.0.1', 'mpmath>=1.0.0']
     try:
         install_requires += packages
     except:
@@ -78,7 +78,7 @@ setup(name='celmech',
     ],
     keywords='astronomy astrophysics celestial-mechanics orbits orbital-mechanics',
     packages=['celmech'],
-    install_requires=['theano', 'mpmath>=1.0.0', 'sympy>=1.1.1', 'rebound>=3.5.11', 'reboundx>=3.1.0', 'numpy', 'scipy>=1.2.0'],
+    install_requires=['theano', 'mpmath>=1.0.0', 'sympy>=1.1.1', 'rebound>=4.0.1', 'reboundx>=3.1.0', 'numpy', 'scipy>=1.2.0'],
     test_suite="celmech.test",
     ext_modules = [libcelmechmodule],
     zip_safe=False)


### PR DESCRIPTION
With these changes the celmech unit tests pass when used with REBOUND Version 4. Other changes might be required (The CI doesn't run the notebooks and I didn't check them manually).