### PR TITLE
fixed get_fg_coefficients function call refactoring

### DIFF
--- a/celmech/planar_poincare.py
+++ b/celmech/planar_poincare.py
@@ -1,7 +1,7 @@
 import numpy as np
 from sympy import symbols, S, binomial, summation, sqrt, cos, sin, Function,atan2,expand_trig
 from celmech.hamiltonian import Hamiltonian
-from celmech.disturbing_function import get_fg_coeffs, general_order_coefficient, secular_DF,laplace_B, laplace_coefficient
+from celmech.disturbing_function import get_fg_coefficients, general_order_coefficient, secular_DF,laplace_B, laplace_coefficient
 from celmech.transformations import masses_to_jacobi, masses_from_jacobi
 from celmech.resonances import resonance_jk_list
 from itertools import combinations

--- a/celmech/resonances.py
+++ b/celmech/resonances.py
@@ -46,7 +46,7 @@ def resonance_pratio_span(mu1,mu2,Z0,res_j,res_k):
     res_pratio = float(res_j - res_k) /float(res_j)
     alpha = res_pratio**(2./3.)
     beta = mu2 / mu1 / np.sqrt(alpha)
-    f,g = df.get_fg_coeffs(res_j,res_k)
+    f,g = df.get_fg_coefficients(res_j,res_k)
 
     # Pendulum approximation: 
     #        H(P,Q) =     (1/2)A P^2 + B cos(Q)
@@ -63,7 +63,7 @@ def pendulum_approx_coeffs(mu1,mu2,res_j,res_k):
     res_pratio = float(res_j - res_k) /float(res_j)
     alpha = res_pratio**(2./3.)
     beta = mu2 / mu1 / np.sqrt(alpha)
-    f,g = df.get_fg_coeffs(res_j,res_k)
+    f,g = df.get_fg_coefficients(res_j,res_k)
     # Pendulum approximation: 
     #        H(P,Q) =     (1/2)A P^2 + B * Z0^k cos(Q)
     A = 1.5 * (res_j*res_j + beta * res_j * (res_j-res_k))


### PR DESCRIPTION
commit a1b36e6c4d069dfe00347bdc945d4e213234e289 changes get_fg_coeffs->get_fg_coefficients but new name was not updated everywhere, this causes resonance_pratio_span() function to raise errors when called which has now been fixed.